### PR TITLE
外部APIに接続するモジュールのディレクトリ名を`api` -> `apis` へ変更した際にテストエラーになっていたのでjestの設定を修正

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/pages', '<rootDir>/api'],
+  roots: ['<rootDir>/pages', '<rootDir>/apis'],
   setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
   transform: {


### PR DESCRIPTION
# issue
なし

# 関連PR
vercelにデプロイすると警告が出て、pages/apiが正しく動かなくなったので修正 #13

# 対応したこと
テストエラーになっていたのでjestの設定をテストエラーにならないように修正