### PR TITLE
都道府県別総人口データ取得に関わるファイル群の命名を変更

### DIFF
--- a/apis/resas/RESASApi.ts
+++ b/apis/resas/RESASApi.ts
@@ -3,7 +3,7 @@ import { RESASApiPrefectureResponse } from '../../types/api/resas/RESASApiPrefec
 import { RESASApiConfig } from '../../types/api/resas/RESASApiConfig'
 import { Prefecture } from '../../types/Prefecture'
 import { RESASApiPopulationCompositionResponse } from '../../types/api/resas/RESASApiPopulationCompositionResponse'
-import { PopulationComposition } from '../../types/PopulationComposition'
+import { PopulationCompositionData } from '../../types/PopulationCompositionData'
 
 export async function RESASApiPrefectures(): Promise<Prefecture[] | undefined> {
   return await axios
@@ -17,9 +17,9 @@ export async function RESASApiPrefectures(): Promise<Prefecture[] | undefined> {
     })
 }
 
-export async function RESASApiPopulationComposition(
+export async function RESASApiPopulationTotal(
   prefCode: number
-): Promise<PopulationComposition[] | undefined> {
+): Promise<PopulationCompositionData[] | undefined> {
   return await axios
     .get<RESASApiPopulationCompositionResponse>(
       populationCompositionUrl(prefCode),

--- a/apis/resas/__tests__/RESASApiPopulationTotal.spec.ts
+++ b/apis/resas/__tests__/RESASApiPopulationTotal.spec.ts
@@ -1,4 +1,4 @@
-import { RESASApiPopulationComposition } from '../RESASApi'
+import { RESASApiPopulationTotal } from '../RESASApi'
 import axios from 'axios'
 
 jest.mock('axios')
@@ -26,7 +26,7 @@ describe('api/resas/RESASApiPopulationComposition', () => {
       })
 
       setEnv('aaa', 'hoge.com')
-      const result = await RESASApiPopulationComposition(1)
+      const result = await RESASApiPopulationTotal(1)
 
       if (!result) fail()
 
@@ -38,20 +38,20 @@ describe('api/resas/RESASApiPopulationComposition', () => {
     it('RESAS_API_KEYがない', async () => {
       setEnv('', 'hoge.com')
 
-      await expect(RESASApiPopulationComposition(1)).rejects.toThrowError(Error)
+      await expect(RESASApiPopulationTotal(1)).rejects.toThrowError(Error)
     })
 
     it('RESAS_API_ENDPOINTがない', async () => {
       setEnv('aaa', '')
 
-      await expect(RESASApiPopulationComposition(1)).rejects.toThrowError(Error)
+      await expect(RESASApiPopulationTotal(1)).rejects.toThrowError(Error)
     })
 
     it('RESAS APIをコールしてエラーが発生する(axios get catch)', async () => {
       ;(axios.get as jest.Mock).mockRejectedValue(new Error('error'))
 
       setEnv('aaa', 'hoge.com')
-      const result = await RESASApiPopulationComposition(1)
+      const result = await RESASApiPopulationTotal(1)
 
       if (!result) fail()
 

--- a/pages/api/population/total/[prefCode].ts
+++ b/pages/api/population/total/[prefCode].ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PopulationComposition } from '../../../../types/PopulationComposition'
 import { ApiError } from '../../../../types/pages/ApiError'
-import { RESASApiPopulationComposition } from '../../../../apis/resas/RESASApi'
+import { RESASApiPopulationTotal } from '../../../../apis/resas/RESASApi'
+import { PopulationCompositionData } from '../../../../types/PopulationCompositionData'
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PopulationComposition[] | ApiError>
+  res: NextApiResponse<PopulationCompositionData[] | ApiError>
 ) {
   const { prefCode } = req.query
   if (inValidPrefCode(prefCode)) {
@@ -13,8 +13,8 @@ export default async function handler(
     return
   }
 
-  await RESASApiPopulationComposition(Number(prefCode))
-    .then((value: PopulationComposition[] | undefined) => {
+  await RESASApiPopulationTotal(Number(prefCode))
+    .then((value: PopulationCompositionData[] | undefined) => {
       if (!value || value.length === 0) {
         setErrorResponse(res)
         return
@@ -37,7 +37,7 @@ function inValidPrefCode(prefCode: string | string[]): boolean {
 }
 
 function setErrorResponse(
-  res: NextApiResponse<PopulationComposition[] | ApiError>
+  res: NextApiResponse<PopulationCompositionData[] | ApiError>
 ): void {
   res.status(500).json({ errorMessage: 'エラーが発生しました' })
 }

--- a/pages/api/population/total/__tests__/[prefCode].spec.ts
+++ b/pages/api/population/total/__tests__/[prefCode].spec.ts
@@ -3,12 +3,12 @@ import httpMocks, { MockResponse } from 'node-mocks-http'
 import { expect } from '@jest/globals'
 import * as RESASApi from '../../../../../apis/resas/RESASApi'
 import handler from '../[prefCode]'
-import { PopulationComposition } from '../../../../../types/PopulationComposition'
+import { PopulationCompositionData } from '../../../../../types/PopulationCompositionData'
 
 describe('pages/api/population/composition', () => {
   describe('正常系', () => {
     it('総人口データが返ってくる', async () => {
-      const prefectures: PopulationComposition[] = [
+      const prefectures: PopulationCompositionData[] = [
         { year: 1980, value: 12817 },
         { year: 1985, value: 12707 },
         { year: 1990, value: 12571 },
@@ -82,10 +82,12 @@ function createRequestMock(prefCode: number | string | null) {
   })
 }
 
-function setupMock(prefectures: PopulationComposition[]): void {
+function setupMock(prefectures: PopulationCompositionData[]): void {
   jest
-    .spyOn(RESASApi, 'RESASApiPopulationComposition')
+    .spyOn(RESASApi, 'RESASApiPopulationTotal')
     .mockReturnValue(
-      new Promise<PopulationComposition[]>((resolve) => resolve(prefectures))
+      new Promise<PopulationCompositionData[]>((resolve) =>
+        resolve(prefectures)
+      )
     )
 }

--- a/types/PopulationComposition.ts
+++ b/types/PopulationComposition.ts
@@ -1,4 +1,0 @@
-export type PopulationComposition = {
-  year: number
-  value: number
-}

--- a/types/PopulationCompositionData.ts
+++ b/types/PopulationCompositionData.ts
@@ -1,0 +1,4 @@
+export type PopulationCompositionData = {
+  year: number
+  value: number
+}

--- a/types/api/resas/RESASApiPopulationCompositionResponse.ts
+++ b/types/api/resas/RESASApiPopulationCompositionResponse.ts
@@ -1,4 +1,4 @@
-import { PopulationComposition } from '../../PopulationComposition'
+import { PopulationCompositionData } from '../../PopulationCompositionData'
 
 export type RESASApiPopulationCompositionResponse = {
   statusCode?: string
@@ -6,6 +6,6 @@ export type RESASApiPopulationCompositionResponse = {
   description?: string
   result?: {
     boundaryYear: string
-    data: { label: string; data: PopulationComposition[] }[]
+    data: { label: string; data: PopulationCompositionData[] }[]
   }
 }


### PR DESCRIPTION
# issue
なし

# 対応したこと
都道府県別総人口データ取得に関わるファイル群の命名を変更

# 対応理由
`population composition: 人口構成` より `total population: 総人口` の方が適切だと思ったため
